### PR TITLE
Add MergePatch(..) method

### DIFF
--- a/DelphiUtils_Test.dproj
+++ b/DelphiUtils_Test.dproj
@@ -1,0 +1,117 @@
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <ProjectGuid>{AB4E1927-47FD-4FFB-8B36-6DD1E8DD0764}</ProjectGuid>
+        <MainSource>DelphiUtils_Test.dpr</MainSource>
+        <Base>True</Base>
+        <Config Condition="'$(Config)'==''">Debug</Config>
+        <TargetedPlatforms>1</TargetedPlatforms>
+        <AppType>Console</AppType>
+        <FrameworkType>None</FrameworkType>
+        <ProjectVersion>18.1</ProjectVersion>
+        <Platform Condition="'$(Platform)'==''">Win32</Platform>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Base' or '$(Base)'!=''">
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win32' and '$(Base)'=='true') or '$(Base_Win32)'!=''">
+        <Base_Win32>true</Base_Win32>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Release' or '$(Cfg_1)'!=''">
+        <Cfg_1>true</Cfg_1>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Debug' or '$(Cfg_2)'!=''">
+        <Cfg_2>true</Cfg_2>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win32' and '$(Cfg_2)'=='true') or '$(Cfg_2_Win32)'!=''">
+        <Cfg_2_Win32>true</Cfg_2_Win32>
+        <CfgParent>Cfg_2</CfgParent>
+        <Cfg_2>true</Cfg_2>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base)'!=''">
+        <DCC_DcuOutput>.\$(Platform)\$(Config)\Dcu\</DCC_DcuOutput>
+        <DCC_ExeOutput>.\$(Platform)\$(Config)</DCC_ExeOutput>
+        <DCC_UnitSearchPath>$(BDS)\Source\DUnit\src;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <DCC_ImageBase>00400000</DCC_ImageBase>
+        <DCC_Namespace>Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;Bde;System;Xml;Data;Datasnap;Web;Soap;Vcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;$(DCC_Namespace)</DCC_Namespace>
+        <Icns_MainIcns>$(BDS)\bin\delphi_PROJECTICNS.icns</Icns_MainIcns>
+        <DCC_F>false</DCC_F>
+        <SanitizedProjectName>DelphiUtils_Test</SanitizedProjectName>
+        <VerInfo_Locale>2057</VerInfo_Locale>
+        <DCC_K>false</DCC_K>
+        <VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=1.0.0.0;Comments=;CFBundleName=</VerInfo_Keys>
+        <DCC_N>false</DCC_N>
+        <DCC_E>false</DCC_E>
+        <DCC_S>false</DCC_S>
+        <Icon_MainIcon>$(BDS)\bin\delphi_PROJECTICON.ico</Icon_MainIcon>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Win32)'!=''">
+        <VerInfo_Locale>1033</VerInfo_Locale>
+        <DCC_Namespace>Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;Bde;$(DCC_Namespace)</DCC_Namespace>
+        <VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_1)'!=''">
+        <DCC_Define>RELEASE;$(DCC_Define)</DCC_Define>
+        <DCC_LocalDebugSymbols>false</DCC_LocalDebugSymbols>
+        <DCC_SymbolReferenceInfo>0</DCC_SymbolReferenceInfo>
+        <DCC_DebugInformation>0</DCC_DebugInformation>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_2)'!=''">
+        <DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>
+        <DCC_Optimize>false</DCC_Optimize>
+        <DCC_GenerateStackFrames>true</DCC_GenerateStackFrames>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_2_Win32)'!=''">
+        <DCC_ExeOutput>.\$(Platform)\$(Config)</DCC_ExeOutput>
+        <VerInfo_Locale>1033</VerInfo_Locale>
+        <Manifest_File>None</Manifest_File>
+        <VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
+    </PropertyGroup>
+    <ItemGroup>
+        <DelphiCompile Include="$(MainSource)">
+            <MainSource>MainSource</MainSource>
+        </DelphiCompile>
+        <DCCReference Include="Utils.JSON.Test.pas"/>
+        <DCCReference Include="Utils.JSON.pas"/>
+        <BuildConfiguration Include="Debug">
+            <Key>Cfg_2</Key>
+            <CfgParent>Base</CfgParent>
+        </BuildConfiguration>
+        <BuildConfiguration Include="Base">
+            <Key>Base</Key>
+        </BuildConfiguration>
+        <BuildConfiguration Include="Release">
+            <Key>Cfg_1</Key>
+            <CfgParent>Base</CfgParent>
+        </BuildConfiguration>
+    </ItemGroup>
+    <ProjectExtensions>
+        <Borland.Personality>Delphi.Personality.12</Borland.Personality>
+        <Borland.ProjectType/>
+        <BorlandProject>
+            <Delphi.Personality>
+                <Source>
+                    <Source Name="MainSource">DelphiUtils_Test.dpr</Source>
+                </Source>
+                <Excluded_Packages>
+                    <Excluded_Packages Name="$(BDSBIN)\bcboffice2k230.bpl">Embarcadero C++Builder Office 2000 Servers Package</Excluded_Packages>
+                    <Excluded_Packages Name="$(BDSBIN)\bcbofficexp230.bpl">Embarcadero C++Builder Office XP Servers Package</Excluded_Packages>
+                    <Excluded_Packages Name="$(BDSBIN)\dcloffice2k230.bpl">Microsoft Office 2000 Sample Automation Server Wrapper Components</Excluded_Packages>
+                    <Excluded_Packages Name="$(BDSBIN)\dclofficexp230.bpl">Microsoft Office XP Sample Automation Server Wrapper Components</Excluded_Packages>
+                </Excluded_Packages>
+            </Delphi.Personality>
+            <Platforms>
+                <Platform value="Win32">True</Platform>
+            </Platforms>
+        </BorlandProject>
+        <ProjectFileVersion>12</ProjectFileVersion>
+    </ProjectExtensions>
+    <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
+    <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
+</Project>

--- a/Utils.JSON.Test.pas
+++ b/Utils.JSON.Test.pas
@@ -17,6 +17,93 @@ type
     procedure ObjectEquals_TextField();
     procedure ObjectEquals_DifferentOrder();
     procedure ObjectEquals_NestedObject();
+
+	//   ORIGINAL        PATCH            RESULT
+	//   ------------------------------------------
+	//   {"a":"b"}       {"a":null}      {}
+	procedure MergePatch_RemovesNullValues1();
+
+	//   ORIGINAL        PATCH            RESULT
+	//   ------------------------------------------
+	//   {"a":"b",       {"a":null}      {"b":"c"}
+	//    "b":"c"}
+	procedure MergePatch_RemovesNullValues2();
+
+	//   ORIGINAL        PATCH            RESULT
+	//   ------------------------------------------
+	//   {"a": {         {"a": {         {"a": {
+	//     "b": "c"}       "b": "d",       "b": "d"
+	//   }                 "c": null}      }
+	//                   }               }
+	procedure MergePatch_RemoveSomethingThatDoesNotExist();
+
+	//   ORIGINAL        PATCH            RESULT
+	//   ------------------------------------------
+	//   {"a":"foo"}     null            null
+	procedure MergePatch_RemovesEverything();
+
+	//   ORIGINAL        PATCH            RESULT
+	//   ------------------------------------------
+	//   {"a":"b"}       {"a":"c"}       {"a":"c"}
+	procedure MergePatch_ReplacesValue();
+
+	//   ORIGINAL        PATCH            RESULT
+	//   ------------------------------------------
+	//   {"a":["b"]}     {"a":"c"}       {"a":"c"}
+	procedure MergePatch_ReplacesArray();
+
+	//   ORIGINAL        PATCH            RESULT
+	//   ------------------------------------------
+	//   {"a":"c"}       {"a":["b"}}       {"a":["b"]}
+	procedure MergePatch_ReplacesValueWithArray();
+
+	//   ORIGINAL        PATCH            RESULT
+	//   ------------------------------------------
+	//   {"a":"b"}       {"b":"c"}       {"a":"b",
+	//                                    "b":"c"}
+	procedure MergePatch_AddsPair();
+
+	//   ORIGINAL        PATCH            RESULT
+	//   ------------------------------------------
+	//   ["a","b"]       ["c","d"]       ["c","d"]
+	procedure MergePath_ReplacesArrayWithOtherArray();
+
+	//   ORIGINAL        PATCH            RESULT
+	//   ------------------------------------------
+	//   {"a":"b"}       ["c"]           ["c"]
+	procedure MergePath_ReplacesObjectWithArray();
+
+	//   ORIGINAL        PATCH            RESULT
+	//   ------------------------------------------
+	//   [1,2]           {"a":"b",       {"a":"b"}
+	//                    "c":null}
+	procedure MergePath_ReplacesArrayWithObject();
+
+	//   ORIGINAL        PATCH            RESULT
+	//   ------------------------------------------
+	//   {"a":"foo"}     "bar"           "bar"
+	procedure MergePatch_ReplacesObjectWithString();
+
+	//   ORIGINAL        PATCH            RESULT
+	//   ------------------------------------------
+	//   {"a": [         {"a": [1]}      {"a": [1]}
+	//     {"b":"c"}
+	//    ]
+	//   }
+	procedure MergePatch_ReplacesArrayWithArray();
+
+	//   ORIGINAL        PATCH            RESULT
+	//   ------------------------------------------
+	//   {"e":null}      {"a":1}         {"e":null,
+	//                                    "a":1}
+	procedure MergePatch_AddsPair_ExistingNullValue();
+	//   ORIGINAL        PATCH            RESULT
+	//   ------------------------------------------
+	//   {}              {"a":            {"a":
+	//                    {"bb":           {"bb":
+	//                     {"ccc":          {}}}
+	//					  null}}}
+	procedure MergePatch_RemovesSomethingThatDoesNotExist2();
   end;
 
 implementation uses System.Json, System.Json.Builders, System.Json.Writers, System.SysUtils;
@@ -102,6 +189,359 @@ begin
   finally
     a.Free(); b.Free(); c.Free();
   end;
+end;
+
+procedure TestTJsonHelper.MergePatch_AddsPair();
+var
+	target, patch: TJsonValue;
+	result: TJsonValue;
+begin
+	target := nil; patch := nil; result := nil;
+	try
+		target := TJSONObject.ParseJSONValue('{"a":"b"}');
+		patch := TJSONObject.ParseJSONValue('{"b": "c"}');
+		result := TJSONHelper.MergePatch(target, patch);
+		Check(result <> patch, 'result <> patch');
+		Check(result <> target, 'result <> target');
+		Check(result is TJSONObject, 'result is TJSONObject');
+		//   {"a":"b"}       {"b":"c"}       {"a":"b",
+		//                                    "b":"c"}
+
+		CheckEquals(2, (result as TJsonObject).Count, 'result.count');
+		CheckEqualsString('b', (result as TJsonObject).GetValue<String>('a'), 'a');
+		CheckEqualsString('c', (result as TJsonObject).GetValue<String>('b'), 'b');
+	finally
+		target.Free(); patch.Free(); result.Free();
+	end;
+end;
+
+procedure TestTJsonHelper.MergePatch_AddsPair_ExistingNullValue();
+var
+	target, patch: TJsonValue;
+	result: TJsonValue;
+	resultObj: TJsonObject;
+begin
+	target := nil; patch := nil; result := nil;
+	try
+		target := TJSONObject.ParseJSONValue('{"e":null}');
+		patch := TJSONObject.ParseJSONValue('{"a":1}');
+		result := TJSONHelper.MergePatch(target, patch);
+		Check(result <> patch, 'result <> patch');
+		Check(result <> target, 'result <> target');
+		Check(result is TJsonObject, 'result is object');
+		resultObj := (result as TJsonObject);
+
+		CheckEquals(2, resultObj.Count, 'obj.count');
+		Check(resultObj.GetValue('e').Null, 'obj.e is null');
+		CheckEquals(1, resultObj.GetValue<Integer>('a'));
+		//   {"e":null}      {"a":1}         {"e":null,
+		//                                    "a":1}
+	finally
+		target.Free(); patch.Free(); result.Free();
+	end;
+end;
+
+procedure TestTJsonHelper.MergePatch_RemovesEverything();
+var
+	target, patch: TJsonValue;
+	result: TJsonValue;
+begin
+	target := nil; patch := nil; result := nil;
+	try
+		target := TJSONObject.ParseJSONValue('{"a":"foo"}');
+		patch := TJSONObject.ParseJSONValue('null');
+		result := TJSONHelper.MergePatch(target, patch);
+		Check(result <> patch, 'result <> patch');
+		Check(result <> target, 'result <> target');
+		Check(result is TJSONNull, 'result is TJSONNull');
+		//   {"a":"foo"}     null            null
+	finally
+		target.Free(); patch.Free(); result.Free();
+	end;
+end;
+
+procedure TestTJsonHelper.MergePatch_RemovesNullValues1();
+var
+	target, patch: TJsonValue;
+	result: TJsonValue;
+begin
+	target := nil; patch := nil; result := nil;
+	try
+		target := TJSONObject.ParseJSONValue('{"a":"b"}') as TJsonObject;
+		patch := TJSONObject.ParseJSONValue('{"a":null}') as TJsonObject;
+		result := TJSONHelper.MergePatch(target, patch);
+		Check(result <> patch, 'result <> patch');
+		Check(result <> target, 'result <> target');
+		Check(result is TJsonObject, 'result is TJsonObject');
+		CheckEquals(0, (result as TJsonObject).Count);
+		//{"a":"b"}       {"a":null}      {}
+	finally
+		target.Free(); patch.Free(); result.Free();
+	end;
+end;
+
+procedure TestTJsonHelper.MergePatch_RemovesNullValues2();
+var
+	target, patch: TJsonValue;
+	result: TJsonValue;
+begin
+	target := nil; patch := nil; result := nil;
+	try
+		target := TJSONObject.ParseJSONValue('{"a":"b", "b":"c"}') as TJsonObject;
+		patch := TJSONObject.ParseJSONValue('{"a":null}') as TJsonObject;
+		result := TJSONHelper.MergePatch(target, patch);
+		Check(result <> patch);
+		Check(result <> target);
+		Check(result is TJsonObject);
+		CheckEquals(1, (result as TJsonObject).Count);
+		Check((result as TJsonObject).GetValue<String>('b') = 'c');
+		//{"a":"b", "b": "c"}       {"a":null}      {"b": "c"}
+	finally
+		target.Free(); patch.Free(); result.Free();
+	end;
+end;
+
+procedure TestTJsonHelper.MergePatch_RemoveSomethingThatDoesNotExist();
+var
+	target, patch: TJsonValue;
+	result: TJsonValue;
+	obj: TJsonObject;
+begin
+	target := nil; patch := nil; result := nil;
+	try
+		target := TJSONObject.ParseJSONValue('{"a":{"b": "c"}}') as TJsonObject;
+		patch := TJSONObject.ParseJSONValue('{"a":{"b": "d", "c": null}}') as TJsonObject;
+		result := TJSONHelper.MergePatch(target, patch);
+
+		Check(result <> patch); Check(result <> target);
+		Check(result is TJsonObject);
+		CheckEquals(1, (result as TJsonObject).Count);
+
+		obj := (result as TJSONObject).GetValue<TJSONObject>('a');
+		CheckNotNull(obj);
+		CheckEquals(1, obj.Count);
+		CheckEqualsString('d', obj.GetValue<String>('b'));
+
+		// {"a": {         {"a": {         {"a": {
+		//     "b": "c"}       "b": "d",       "b": "d"
+		//   }                 "c": null}      }
+		//				   }               }
+
+	finally
+		target.Free(); patch.Free(); result.Free();
+	end;
+end;
+
+procedure TestTJsonHelper.MergePatch_RemovesSomethingThatDoesNotExist2;
+var
+	target, patch: TJsonValue;
+	expected: TJsonObject;
+	actual: TJsonValue;
+begin
+	target := nil; patch := nil; expected := nil; actual := nil;
+	try
+		target := TJSONObject.Create();
+		patch := TJSONObject.ParseJSONValue('{"a": {"bb": {"ccc": null}}}');
+
+		expected := TJsonObject.ParseJSONValue('{"a": {"bb": {}}}') as TJsonObject;
+		actual := TJSONHelper.MergePatch(target, patch);
+
+		CheckIs(actual, TJsonObject);
+		Check( TJSONHelper.Equals(expected, actual) );
+
+		//   {}              {"a":            {"a":
+		//                    {"bb":           {"bb":
+		//                     {"ccc":          {}}}
+		//					  null}}}
+	finally
+		target.Free(); patch.Free();
+		expected.Free(); actual.Free();
+	end;
+end;
+
+procedure TestTJsonHelper.MergePatch_ReplacesArray();
+var
+	target, patch: TJsonValue;
+	result: TJsonValue;
+begin
+	target := nil; patch := nil; result := nil;
+	try
+		target := TJSONObject.ParseJSONValue('{"a":["b"]}') as TJsonObject;
+		patch := TJSONObject.ParseJSONValue('{"a": "c"}') as TJsonObject;
+		result := TJSONHelper.MergePatch(target, patch);
+
+		Check(target <> patch);
+		Check(result is TJsonObject);
+		CheckEquals(1, (result as TJsonObject).Count);
+		CheckEqualsString('c', (result as TJsonObject).GetValue<String>('a'));
+		//   {"a":["b"]}     {"a":"c"}       {"a":"c"}
+	finally
+		target.Free(); patch.Free(); result.Free();
+	end;
+end;
+
+procedure TestTJsonHelper.MergePatch_ReplacesArrayWithArray;
+var
+	target, patch: TJsonValue;
+	result: TJsonValue;
+	arr: TJsonArray;
+begin
+	target := nil; patch := nil; result := nil;
+	try
+		target := TJSONObject.ParseJSONValue('{"a": [{"b":"c"}]}');
+		patch := TJsonObject.ParseJSONValue('{"a": [1]}');
+		result := TJsonHelper.MergePatch(target, patch);
+
+		Check(result <> patch); Check(result <> target);
+		Check(result is TJSONObject);
+		CheckEquals(1, (result as TJSONObject).Count, 'object.count');
+		CheckIs((result as TJsonObject).GetValue('a'), TJSONArray, 'a is array');
+		arr := (result as TJsonObject).GetValue('a') as TJsonArray;
+		CheckEquals(1, arr.Count, 'array.count');
+		CheckEquals(1, arr.Items[0].GetValue<Integer>(), 'array[0]');
+
+		//   {"a": [         {"a": [1]}      {"a": [1]}
+		//     {"b":"c"}
+		//    ]}
+	finally
+		target.Free(); patch.Free(); result.Free();
+	end;
+end;
+
+procedure TestTJsonHelper.MergePatch_ReplacesObjectWithString();
+var
+	target, patch: TJsonValue;
+	result: TJsonValue;
+begin
+	target := nil; patch := nil; result := nil;
+	try
+		target := TJSONObject.ParseJSONValue('{"a":"foo"}') as TJsonObject;
+		patch := TJSONObject.ParseJSONValue('"bar"') as TJSONString;
+		result := TJSONHelper.MergePatch(target, patch);
+
+		Check(result <> patch);
+		Check(result is TJSONString);
+		CheckEqualsString('bar', (result as TJSONString).Value());
+		//   {"a":"foo"}     "bar"           "bar"
+	finally
+		target.Free(); patch.Free(); result.Free();
+	end;
+end;
+
+procedure TestTJsonHelper.MergePatch_ReplacesValue();
+var
+	target, patch: TJsonValue;
+	result: TJsonValue;
+begin
+	target := nil; patch := nil; result := nil;
+	try
+		target := TJSONObject.ParseJSONValue('{"a":"b"}') as TJsonObject;
+		patch := TJSONObject.ParseJSONValue('{"a": "c"}') as TJsonObject;
+		result := TJSONHelper.MergePatch(target, patch);
+
+		Check(result <> patch); Check(result <> target);
+		Check(result is TJsonObject);
+		CheckEquals(1, (result as TJsonObject).Count);
+		CheckEqualsString('c', (result as TJsonObject).GetValue<String>('a'));
+		//   {"a":"b"}       {"a":"c"}       {"a":"c"}
+	finally
+		target.Free(); patch.Free(); result.Free();
+	end;
+end;
+
+procedure TestTJsonHelper.MergePatch_ReplacesValueWithArray();
+var
+	target, patch: TJsonValue;
+	result: TJsonValue;
+	arr: TJsonArray;
+begin
+	target := nil; patch := nil; result := nil;
+	try
+		target := TJSONObject.ParseJSONValue('{"a":"c"}');
+		patch := TJSONObject.ParseJSONValue('{"a": ["b"]}');
+		result := TJSONHelper.MergePatch(target, patch);
+
+		Check(result <> patch); Check(result <> target);
+		Check(result is TJsonObject);
+		CheckEquals(1, (result as TJsonObject).Count);
+		CheckIs((result as TJsonObject).Values['a'], TJSONArray, 'a is array');
+		arr := (result as TJsonObject).Values['a'] as TJSONArray;
+		CheckEquals(1, arr.Count, 'array.count');
+		CheckIs(arr.Items[0], TJsonString);
+		CheckEqualsString('b', arr.Items[0].GetValue<String>());
+		//   {"a":"c"}       {"a":["b"}}       {"a":["b"]}
+	finally
+		target.Free(); patch.Free(); result.Free();
+	end;
+end;
+
+procedure TestTJsonHelper.MergePath_ReplacesArrayWithObject();
+var
+	target, patch: TJsonValue;
+	result: TJsonValue;
+
+begin
+	target := nil; patch := nil; result := nil;
+	try
+		target := TJSONObject.ParseJSONValue('[1,2]');
+		patch := TJSONObject.ParseJSONValue('{"a": "b", "c": null}');
+		result := TJSONHelper.MergePatch(target, patch);
+
+		Check(result <> patch); Check(result <> target);
+		Check(result is TJsonObject, 'result is object');
+		CheckEquals(1, (result as TJsonObject).Count, 'object.count');
+		CheckEqualsString('b', (result as TJSONObject).GetValue<String>('a'));
+		//   [1,2]           {"a":"b",       {"a":"b"}
+		//                    "c":null}
+	finally
+		target.Free(); patch.Free(); result.Free();
+	end;
+end;
+
+procedure TestTJsonHelper.MergePath_ReplacesArrayWithOtherArray();
+var
+	target, patch: TJsonValue;
+	result: TJsonValue;
+	arr: TJsonArray;
+begin
+	target := nil; patch := nil; result := nil;
+	try
+		target := TJSONObject.ParseJSONValue('["a","b"]');
+		patch := TJSONObject.ParseJSONValue('["c","d"]');
+		result := TJSONHelper.MergePatch(target, patch);
+
+		Check(result <> patch); Check(result <> target);
+		Check(result is TJSONArray, 'result is array');
+		arr := (result as TJSONArray);
+
+		CheckEquals(2, arr.Count, 'array.count');
+		CheckEqualsString('c', arr.Items[0].GetValue<String>());
+		CheckEqualsString('d', arr.Items[1].GetValue<String>());
+		//   ["a","b"]       ["c","d"]       ["c","d"]
+	finally
+		target.Free(); patch.Free(); result.Free();
+	end;
+end;
+
+procedure TestTJsonHelper.MergePath_ReplacesObjectWithArray();
+var
+	target, patch: TJsonValue;
+	result: TJsonValue;
+begin
+	target := nil; patch := nil; result := nil;
+	try
+		target := TJSONObject.ParseJSONValue('{"a": "b"}');
+		patch := TJSONObject.ParseJSONValue('["c"]');
+		result := TJSONHelper.MergePatch(target, patch);
+
+		Check(result <> patch);
+		Check(result is TJSONArray);
+		CheckEquals(1, (result as TJSONArray).Count, 'array.count');
+		CheckEqualsString('c', (result as TJsonArray).Items[0].GetValue<String>());
+		//   {"a":"b"}       ["c"]           ["c"]
+	finally
+		target.Free(); patch.Free(); result.Free();
+	end;
 end;
 
 procedure TestTJsonHelper.ArrayEquals_Integer();


### PR DESCRIPTION
Creates a new `TJsonValue`, based on `target: TJsonValue` and `patch: TJsonValue`.
`var result := TJsonHelper.MergePatch(target, patch)`

**Example:**
target = `{
  "id": "ABC 123",
  "numbers": [1,2,3],
  "message": "Hallo Welt"
}`
patch = `{
  "numbers": [10],
  "message": null
}`
result = `{
  "id": "ABC 123",
  "numbers": [10]
}`

Basically a Delphi implementation for the following pseudo-code from https://tools.ietf.org/html/rfc7396:
```
   define MergePatch(Target, Patch):
     if Patch is an Object:
       if Target is not an Object:
         Target = {} # Ignore the contents and set it to an empty Object
       for each Name/Value pair in Patch:
         if Value is null:
           if Name exists in Target:
             remove the Name/Value pair from Target
         else:
           Target[Name] = MergePatch(Target[Name], Value)
       return Target
     else:
       return Patch
```
Includes the [15 test cases from the RFC](https://tools.ietf.org/html/rfc7396#appendix-A) for DUnit.