### PR TITLE
Improve float comparison for TJsonHelper.Equals(a, b)

### DIFF
--- a/Utils.JSON.Test.pas
+++ b/Utils.JSON.Test.pas
@@ -13,6 +13,8 @@ type
     procedure NullEqualsNull();
     procedure BooleanEquals();
     procedure FloatEquals();
+    procedure FloatEquals_Recursive_UseEpsilon();
+    procedure FloatEquals_UseEpsilon();
     procedure ArrayEquals_Integer();
     procedure ObjectEquals_TextField();
     procedure ObjectEquals_DifferentOrder();
@@ -116,6 +118,55 @@ end;
 procedure TestTJsonHelper.TearDown();
 begin
   // do nothing
+end;
+
+procedure TestTJsonHelper.FloatEquals_Recursive_UseEpsilon();
+const
+  a = '{"someFloat": 3.14}';
+  b = '{"someFloat": 3.1400001}';
+  EPSILON = 1E-3;
+var
+  objA, objB: TJsonObject;
+begin
+  objA := nil; objB := nil;
+  try
+    objA := TJsonObject.ParseJSONValue(a) as TJsonObject;
+    objB := TJsonObject.ParseJSONValue(b) as TJSONObject;
+
+    Check( TJSONHelper.Equals(objA, objB, EPSILON) );
+  finally
+    objA.Free(); objB.Free();
+  end;
+end;
+
+procedure TestTJsonHelper.FloatEquals_UseEpsilon();
+const
+  value_1 = 3.14159265;
+  value_2 = 3.141;
+var
+  a, b, c: TJSONNumber;
+  msg: String;
+begin
+  a := nil; b := nil; c := nil;
+  try
+  a := TJSONNumber.Create(value_1);
+  b := TJSONNumber.Create(value_1);
+  c := TJSONNumber.Create(value_2);
+
+  msg := 'a = b, Epsilon = 0';
+  Check( TJSONHelper.Equals(a, b, 0), msg );
+
+  msg := 'a = b, Epsilon = 1E-3';
+  Check( TJSONHelper.Equals(a, b, 1E-3), msg );
+
+  msg := 'a = c, Epsilon = 0';
+  CheckFalse( TJSONHelper.Equals(a, c, 0), msg );
+
+  msg := 'a = c, Epsilon = 1E-3';
+  Check( TJsonHelper.Equals(a, c, 1E-3), msg );
+  finally
+  a.Free(); b.Free(); c.Free();
+  end;
 end;
 
 procedure TestTJsonHelper.ReturnsFalseWhenEitherIsNil();

--- a/Utils.JSON.Test.pas
+++ b/Utils.JSON.Test.pas
@@ -19,6 +19,10 @@ type
     procedure ObjectEquals_TextField();
     procedure ObjectEquals_DifferentOrder();
     procedure ObjectEquals_NestedObject();
+    procedure FloatEquals_LeadingZero();
+    procedure CompareFloatWithInt();
+    procedure IntegerEquals();
+    procedure IntegerEquals_LeadingZero();
 
 	//   ORIGINAL        PATCH            RESULT
 	//   ------------------------------------------
@@ -222,6 +226,24 @@ begin
   end;
 end;
 
+procedure TestTJsonHelper.CompareFloatWithInt();
+const
+  a = '{"value": 3}';
+  b = '{"value": 3.0}';
+var
+  objA, objB: TJsonObject;
+begin
+  objA := nil; objB := nil;
+  try
+    objA := TJsonObject.ParseJSONValue(a) as TJsonObject;
+    objB := TJsonObject.ParseJSONValue(b) as TJsonObject;
+
+    CheckFalse( TJsonHelper.Equals(objA, objB) );
+  finally
+    objA.Free(); objB.Free();
+  end;
+end;
+
 procedure TestTJsonHelper.FloatEquals();
 const
   value_1 = 3.14159265;
@@ -239,6 +261,55 @@ begin
     CheckFalse( TJSONHelper.Equals(a, c) );
   finally
     a.Free(); b.Free(); c.Free();
+  end;
+end;
+
+procedure TestTJsonHelper.FloatEquals_LeadingZero();
+var
+  a, b: TJsonValue;
+begin
+  a := nil; b:= nil;
+  try
+    a := TJsonNumber.Create('8.55');
+    b := TJsonNumber.Create('08.55');
+
+    Check( TJSONHelper.Equals(a, b) );
+  finally
+    a.Free(); b.Free();
+  end;
+end;
+
+procedure TestTJsonHelper.IntegerEquals();
+var
+  a, b, c: TJsonNumber;
+begin
+  a := nil; b := nil; c:= nil;
+  try
+    a := TJsonNumber.Create(42);
+    b := TJsonNumber.Create(42);
+    c := TJsonNumber.Create(99);
+
+    Check( TJSonHelper.Equals(a, b) );
+    CheckFalse( TJsonHelper.Equals(a, c) );
+  finally
+    a.Free(); b.Free(); c.Free();
+  end;
+end;
+
+procedure TestTJsonHelper.IntegerEquals_LeadingZero();
+var
+  a, b: TJsonNumber;
+begin
+  a := nil; b := nil;
+  try
+    a := TJsonNumber.Create('042');
+    b := TJsonNumber.Create('42');
+
+    Assert( a.AsInt = b.AsInt );
+
+    Check( TJsonHelper.Equals(a, b) );
+  finally
+    a.Free(); b.Free();
   end;
 end;
 


### PR DESCRIPTION
Comparing `a={"someFloat": 3.14}` and `b={"someFloat": 3.1400001}` with `TJsonHelper.Equals(a, b)` returns `false` because for floats, their **string values** are compared:

https://github.com/flobernd/delphi-utils/blob/1224d34836502c8e771d6e152c288afed1040784/Utils.JSON.pas#L464-L467

I suggest extending the case statement with a special case for floats, where it uses `System.Math.SameValue(a, b)`.

```pascal
jsonFloat:
  begin
    Result := SameValue(
      (A as TJSONNumber).AsDouble,
      (B as TJsonNumber).AsDouble,
      epsilon
    );
    Exit;
  end;
```

Additionally, while we're at it, `TJsonHelper.Equals(..)` should accept an optional `epsilon: Double` parameter for float comparison.
I have also added a few tests for comparing numbers to show that existing behaviour has not been changed otherwise.